### PR TITLE
[PKG-2641] starlette 0.27.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,6 @@
+upload_without_merge: true
+
+upload_channels:
+  - sk_test
+channels:
+  - sk_test

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,0 @@
-upload_without_merge: true
-
-upload_channels:
-  - sk_test
-channels:
-  - sk_test

--- a/recipe/build_base.sh
+++ b/recipe/build_base.sh
@@ -1,9 +1,0 @@
-#!/bin/bash
-set -euo pipefail
-
-PIP_NO_BUILD_ISOLATION=False \
-    PIP_NO_DEPENDENCIES=True \
-    PIP_IGNORE_INSTALLED=True \
-    PIP_NO_INDEX=True \
-    PYTHONDONTWRITEBYTECODE=True \
-    ${PYTHON} -m pip install . --no-deps -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "starlette" %}
-{% set version = "0.17.0" %}
+{% set version = "0.27.0" %}
 
 package:
   name: {{ name|lower }}-recipe
@@ -7,42 +7,55 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 31a889e7d7bf487f70d9d197ed7efadb47fa938c58626ed93e381480833c5b84
+  sha256: 6a6b0d042acb8d469a01eba54e9cda6cbd24ac602c4cd016723117d6a7e73b75
 
 build:
   number: 0
+  skip: true  # [py<37]
+
+requirements:
+  host:
+    - python
+    - pip
+    - hatchling
 
 outputs:
   - name: {{ name }}
     build:
-      noarch: python
-    script: build_base.sh
+      script: python -m pip install . --no-deps --no-build-isolation -vv
     requirements:
       host:
-        - python >=3.6
+        - python
         - pip
+        - hatchling
       run:
-        - python >=3.6
-        - anyio >=3.0.0,<4.0.0a
+        - python
+        - anyio >=3.4.0,<5
+        - typing_extensions >=3.10.0  # [py<310]
     test:
+      imports:
+        - starlette
+      requires:
+        - pip
       commands:
-        - python -c "from starlette import *"
+        - pip check
 
   - name: {{ name }}-full
     build:
-      noarch: python
+      script: echo Nothing to do.
     requirements:
       host:
-        - python >=3.6
+        - python
         - pip
+        - hatchling
       run:
-        - python >=3.6
+        - python
         - {{ pin_subpackage('starlette', exact=True) }}
         - itsdangerous
         - jinja2
         - python-multipart
         - pyyaml
-        - requests
+        - httpx >=0.22.0
     test:
       commands:
         - python -c "from starlette import *"
@@ -52,10 +65,9 @@ about:
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE.md
-  summary: The little ASGI framework that shines. ✨
+  summary: The little ASGI framework that shines
   description: |
-    Starlette is a lightweight [ASGI](https://asgi.readthedocs.io/en/latest/)
-    framework/toolkit.
+    Starlette is a lightweight [ASGI](https://asgi.readthedocs.io/en/latest/) framework/toolkit.
 
     It is ideal for building high performance asyncio services, and supports
     both HTTP and WebSockets.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,6 +43,8 @@ outputs:
   - name: {{ name }}-full
     build:
       script: echo Nothing to do.
+      # httpx isn't available on s390x
+      skip: true  # [s390x]
     requirements:
       host:
         - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,7 +49,6 @@ outputs:
       host:
         - python
         - pip
-        - hatchling
       run:
         - python
         - {{ pin_subpackage('starlette', exact=True) }}


### PR DESCRIPTION
Changelog: https://github.com/encode/starlette/releases
License: https://github.com/encode/starlette/blob/master/LICENSE.md
Requirements: https://github.com/encode/starlette/blob/0.27.0/pyproject.toml

Actions:
1. Clean up the recipe:
- Remove [build_base.sh](https://github.com/AnacondaRecipes/starlette-feedstock/pull/2/files#diff-e0638ff31f64a715c0ed3faa90c7b9f61ef3ff28d4a622e89e31923e585394bb)
- Remove `noarch python` from outputs
- Skip `py<37`
- Update the `script` command
- Add the flags `--no-build-isolation -vv` to `script`
- Add missing `hatchling` to `host`
- Fix `python` pinning in `host` and `run`
- Add `pip check`, `test/imports` to the `starlette` output
2. Add a generic host environment for the multi-output package
3. Update `run` dependencies
4. Skip `s390x` for the st`arlette-full` output because of missing `httpx`
5. Fix `doc_url`


Notes:
- `fastapi 0.101.1` requires `starlette >=0.27.0,<0.28.0`, see https://github.com/AnacondaRecipes/fastapi-feedstock/pull/3/files