### PR TITLE
Update to 0.46.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "starlette" %}
-{% set version = "0.38.2" %}
+{% set version = "0.46.2" %}
 
 package:
   name: {{ name|lower }}-recipe
@@ -7,11 +7,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: c7c0441065252160993a1a37cf2a73bb64d271b17303e0b0c1eb7191cfb12d75
+  sha256: 7f7361f34eed179294600af672f565727419830b54b7b084efe44bb82d2fccd5
 
 build:
   number: 0
-  skip: true  # [py<38]
+  skip: true  # [py<39]
 
 requirements:
   host:
@@ -30,7 +30,7 @@ outputs:
         - hatchling
       run:
         - python
-        - anyio >=3.4.0,<5
+        - anyio >=3.6.2,<5
         - typing_extensions >=3.10.0  # [py<310]
     test:
       imports:
@@ -54,9 +54,9 @@ outputs:
         - {{ pin_subpackage('starlette', exact=True) }}
         - itsdangerous
         - jinja2
-        - python-multipart >=0.0.7
+        - python-multipart >=0.0.18
         - pyyaml
-        - httpx >=0.22.0
+        - httpx >=0.27.0,<0.29.0
     test:
       commands:
         - python -c "from starlette import *"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,8 +43,6 @@ outputs:
   - name: {{ name }}-full
     build:
       script: echo Nothing to do.
-      # httpx isn't available on s390x
-      skip: true  # [s390x]
     requirements:
       host:
         - python
@@ -58,7 +56,13 @@ outputs:
         - pyyaml
         - httpx >=0.27.0,<0.29.0
     test:
+      imports:
+        - starlette
+      requires:
+        - pip
+        - python
       commands:
+        - pip check
         - python -c "from starlette import *"
 
 about:


### PR DESCRIPTION
starlette 0.46.2

**Destination channel:** defaults

### Links

- [Upstream repository](https://github.com/encode/starlette/tree/0.46.2)
- Needed for:
  - https://github.com/AnacondaRecipes/sse-starlette-feedstock/pull/2
