### PR TITLE
starlette 1.3.1 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "starlette" %}
-{% set version = "1.2.1" %}
+{% set version = "1.3.1" %}
 
 package:
   name: {{ name|lower }}-recipe
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 9b9b5ebb992e67d6093741e63c2f59e4f6fff986f81163c087867bd7b924b3f6
+  sha256: 05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0
 
 build:
   number: 0
@@ -54,6 +54,7 @@ outputs:
         - python-multipart >=0.0.18
         - pyyaml
         - httpx >=0.27.0,<0.29.0
+        - httpx2 >=2.0.0
     test:
       source_files:
         - tests


### PR DESCRIPTION
starlette 1.3.1 

**Destination channel:** Defaults

### Links

- [PKG-16379]
- dev_url:        https://github.com/encode/starlette/tree/1.3.1
- conda_forge:    https://github.com/conda-forge/starlette-feedstock
- pypi:           https://pypi.org/project/starlette/1.3.1
- pypi inspector: https://inspector.pypi.io/project/starlette/1.3.1

### Explanation of changes:

- new version number
- `httpx2` is a new (optional) requirement for `-full`


[PKG-16379]: https://anaconda.atlassian.net/browse/PKG-16379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ